### PR TITLE
Parse threshold date

### DIFF
--- a/lib/todo/model/todo_model.dart
+++ b/lib/todo/model/todo_model.dart
@@ -278,6 +278,22 @@ class Todo extends Equatable {
     return dueDateStr != null ? 'due:$dueDateStr' : '';
   }
 
+  DateTime? get thresholdDate {
+    for (String kv in keyValues) {
+      List<String> kvSplitted = kv.split(':');
+      if (kvSplitted[0] == 't') {
+        return str2date(kvSplitted[1]);
+      }
+    }
+
+    return null;
+  }
+
+  String get fmtThresholdDate {
+    final String? thresholdDateStr = date2Str(thresholdDate);
+    return thresholdDateStr != null ? 't:$thresholdDateStr' : '';
+  }
+
   // Core todo constructor with validation logic.
   Todo._({
     required this.id,

--- a/lib/todo/page/todo_list_page.dart
+++ b/lib/todo/page/todo_list_page.dart
@@ -343,7 +343,7 @@ class TodoListTile extends StatelessWidget {
   Widget _buildTitle(BuildContext context) {
     final List<String> items = todo.description.split(' ')
       ..removeWhere(
-        (String item) => item.startsWith('due:'),
+        (String item) => item.startsWith('due:') || item.startsWith('t:'),
       );
 
     return RichText(
@@ -400,6 +400,12 @@ class TodoListTile extends StatelessWidget {
             mono: true,
             iconData: Icons.event,
             label: Todo.date2Str(todo.dueDate!)!,
+          ),
+        if (todo.thresholdDate != null)
+          BasicIconChip(
+            mono: true,
+            iconData: Icons.schedule,
+            label: Todo.date2Str(todo.thresholdDate!)!,
           )
       ],
     );

--- a/lib/todo/page/todo_search_page.dart
+++ b/lib/todo/page/todo_search_page.dart
@@ -169,7 +169,7 @@ class TodoSearchTile extends StatelessWidget {
   Widget _buildTitle(BuildContext context) {
     final List<String> items = todo.description.split(' ')
       ..removeWhere(
-        (String item) => item.startsWith('due:'),
+        (String item) => item.startsWith('due:') || item.startsWith('t:'),
       );
 
     return RichText(
@@ -226,6 +226,12 @@ class TodoSearchTile extends StatelessWidget {
             mono: true,
             iconData: Icons.event,
             label: Todo.date2Str(todo.dueDate!)!,
+          ),
+        if (todo.thresholdDate != null)
+          BasicIconChip(
+            mono: true,
+            iconData: Icons.schedule,
+            label: Todo.date2Str(todo.thresholdDate!)!,
           )
       ],
     );

--- a/test/todo/model/todo_model_test.dart
+++ b/test/todo/model/todo_model_test.dart
@@ -888,6 +888,27 @@ void main() {
     });
   });
 
+  group('todo thresholdDate', () {
+    test('unset', () {
+      final todo = Todo.fromString(
+        value: '2022-11-01 Write some tests',
+      );
+      expect(todo.thresholdDate, null);
+    });
+    test('set', () {
+      final todo = Todo.fromString(
+        value: '2022-11-01 Write some tests t:2023-12-31',
+      );
+      expect(todo.thresholdDate, DateTime(2023, 12, 31));
+    });
+    test('set but invalid', () {
+      final todo = Todo.fromString(
+        value: '2022-11-01 Write some tests t:yyyy-mm-dd',
+      );
+      expect(todo.thresholdDate, null);
+    });
+  });
+
   group('todo toString()', () {
     test('full todo', () {
       const String value =

--- a/test/todo/page/todo_list_page_test.dart
+++ b/test/todo/page/todo_list_page_test.dart
@@ -200,6 +200,47 @@ void main() {
     });
   });
 
+  group('Threshold date', () {
+    setUp(() async {
+      file = fs.file('todoThresholdDate.txt');
+      await file.create();
+      await file.writeAsString(
+        'TodoA t:2024-05-01',
+        flush: true,
+      );
+    });
+    testWidgets('renders threshold date', (tester) async {
+      await tester.pumpWidget(TodoListPageMaterialApp(
+        localFile: file,
+      ));
+      await tester.pumpAndSettle();
+
+      final TodoListTile todoTile =
+          tester.widget<TodoListTile>(find.byType(TodoListTile));
+      expect(
+        find.descendant(
+          of: find.byWidget(todoTile),
+          matching: find.text('TodoA', findRichText: true),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byWidget(todoTile),
+          matching: find.byIcon(Icons.schedule),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byWidget(todoTile),
+          matching: find.text('2024-05-01'),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
   group('Filter', () {
     setUp(() async {
       file = fs.file('todoFilter.txt');


### PR DESCRIPTION
I added support for threshold dates that I'm using for some time now (parsing, UI for it, filter) (ref #47), but before bombarding you with bigger changes I wanted to ask if you have interest to support this? This PR is simply a first stepping stone, that simply parses the value that can be typed by hand, which I believe is a useful addition on its own.

I am happy to submit the rest of the changes, either here or separate PRs - you can see them here: https://github.com/max-baz/ntodotxt/commits/main/